### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/appknox.yml
+++ b/.github/workflows/appknox.yml
@@ -20,6 +20,9 @@
 #    action executes, check the 'Security' tab for results
 
 name: Appknox
+permissions:
+  contents: read
+  security-events: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/BBQQYT/ChaosAlicePro/security/code-scanning/1](https://github.com/BBQQYT/ChaosAlicePro/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file. The best place is at the top level (just after the `name:` and before `on:`), so it applies to all jobs unless overridden. For this workflow, the only action that requires write permissions is the upload of SARIF files to GitHub Advanced Security, which requires `security-events: write`. All other steps (checkout, build, etc.) only require `contents: read`. Therefore, set:

```yaml
permissions:
  contents: read
  security-events: write
```

Insert this block after the `name: Appknox` line (line 22), before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
